### PR TITLE
fix route table route spec

### DIFF
--- a/spec/schemas/route-table.yaml
+++ b/spec/schemas/route-table.yaml
@@ -44,6 +44,9 @@ RouteSpec:
     The target reference can be an instance,
     a gateway or an IP address (v4 or v6) that is part of the
     network the route table is attached to.
+  required:
+  - destinationCidrBlock
+  - targetRef
   properties:
     destinationCidrBlock:
       type: string


### PR DESCRIPTION
The route table `destinationCidrBlock` and `targetRef` where not required, but both are needed for a valid route.