### PR TITLE
126-linter issue makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ lint: resource-apis
 		echo "$(YELLOW)⚠️  No OpenAPI specs found to lint.$(RESET)"; \
 		exit 1; \
 	fi; \
-	$(VACUUM) lint $(VACUUM_LINT_FLAGS) $$SCHEMAS
+	$(VACUUM) lint $(VACUUM_LINT_FLAGS) $$SCHEMAS --fail-severity warn
 
 lint-verbose: resource-apis
 	@echo "$(YELLOW)Linting OpenAPI specs (verbose)...$(RESET)"

--- a/spec/schemas/internet-gateway.yaml
+++ b/spec/schemas/internet-gateway.yaml
@@ -1,4 +1,7 @@
 InternetGateway:
+  description: |
+    An InternetGateway is a resource that provides internet access to a subnet.
+    It is used in conjunction with a RouteTable to enable internet connectivity.
   allOf:
   - $ref: './resource.yaml#/UserResourceMetadata'
   - type: object

--- a/spec/schemas/workspace.yaml
+++ b/spec/schemas/workspace.yaml
@@ -1,4 +1,7 @@
 Workspace:
+  description: |
+    A workspace is a collection of resources.
+    Can contain multiple resources of different types, and it can be used to manage the lifecycle of those resources.
   allOf:
   - $ref: './resource.yaml#/UserResourceMetadata'
   - type: object


### PR DESCRIPTION
closes #126 
Fixed 2 new lint issues and updated the makefile to validate the lint command.
If the lint command returns a warning, the validation will fail.