### PR TITLE
refactor: define dedicated schemas for response and request properties of activityLogSpec

### DIFF
--- a/spec/schemas/activity-log.yaml
+++ b/spec/schemas/activity-log.yaml
@@ -18,42 +18,48 @@ ActivityLogSpec:
       description: User-JWT executing this query
       maxLength: 256
     request:
-      type: object
-      description: Request object
-      properties:
-        verb:
-          type: string
-          description: |
-            Verb that describes the action to be performed on the resource.
-            The verb can be one of the following: get, list, put, delete, post, ..
-          maxLength: 7
-          example: 'get'
-        body:
-          oneOf:
-            - $ref: './block-storage.yaml#/BlockStorageSpec'
-            - $ref: './instance-sku.yaml#/InstanceSkuSpec'
-            - $ref: './instance.yaml#/InstanceSpec'
-            - $ref: './load-balancer.yaml#/NetworkLoadBalancerSpec'
-            - $ref: './network-sku.yaml#/NetworkSkuSpec'
-            - $ref: './network.yaml#/NetworkSpec'
-            - $ref: './nic.yaml#/NicSpec'
-            - $ref: './object-storage.yaml#/ObjectStorageAccountSpec'
-            - $ref: './public-ip.yaml#/PublicIpSpec'
-            - $ref: './rbac.yaml#/RoleAssignmentSpec'
-            - $ref: './rbac.yaml#/RoleSpec'
-            - $ref: './security-group.yaml#/SecurityGroupSpec'
-            - $ref: './storage-sku.yaml#/StorageSkuSpec'
-            - $ref: './subnet.yaml#/SubnetSpec'
-            - $ref: './workspace.yaml#/WorkspaceSpec'
-        resource:
-          type: string
-          maxLength: 2000
+      $ref: '#/RequestObject'
     response:
-      type: object
-      description: Response object
-      properties:
-        code:
-          type: number
-          minimum: 100
-          maximum: 599
-          example: 202
+      $ref: '#/ResponseObject'
+
+RequestObject:
+  type: object
+  description: Request object
+  properties:
+    verb:
+      type: string
+      description: |
+        Verb that describes the action to be performed on the resource.
+        The verb can be one of the following: get, list, put, delete, post, ..
+      maxLength: 7
+      example: 'get'
+    body:
+      oneOf:
+        - $ref: './block-storage.yaml#/BlockStorageSpec'
+        - $ref: './instance-sku.yaml#/InstanceSkuSpec'
+        - $ref: './instance.yaml#/InstanceSpec'
+        - $ref: './load-balancer.yaml#/NetworkLoadBalancerSpec'
+        - $ref: './network-sku.yaml#/NetworkSkuSpec'
+        - $ref: './network.yaml#/NetworkSpec'
+        - $ref: './nic.yaml#/NicSpec'
+        - $ref: './object-storage.yaml#/ObjectStorageAccountSpec'
+        - $ref: './public-ip.yaml#/PublicIpSpec'
+        - $ref: './rbac.yaml#/RoleAssignmentSpec'
+        - $ref: './rbac.yaml#/RoleSpec'
+        - $ref: './security-group.yaml#/SecurityGroupSpec'
+        - $ref: './storage-sku.yaml#/StorageSkuSpec'
+        - $ref: './subnet.yaml#/SubnetSpec'
+        - $ref: './workspace.yaml#/WorkspaceSpec'
+    resource:
+      type: string
+      maxLength: 2000
+
+ResponseObject:
+  type: object
+  description: Response object
+  properties:
+    code:
+      type: number
+      minimum: 100
+      maximum: 599
+      example: 202


### PR DESCRIPTION
With the original definition of ActivityLogSpec, the go model is generated with anonymous struct types embedded in it, which makes it difficult to use.
```go
type ActivityLogSpec struct {
	// Request Request object
	Request *struct {
		Body     *ActivityLogSpec_Request_Body `json:"body,omitempty"`
		Resource *string                       `json:"resource,omitempty"`

		// Verb Verb that describes the action to be performed on the resource.
		// The verb can be one of the following: get, list, put, delete, post, ..
		Verb *string `json:"verb,omitempty"`
	} `json:"request,omitempty"`

	// Response Response object
	Response *struct {
		Code *float32 `json:"code,omitempty"`
	} `json:"response,omitempty"`

	// Subject User-JWT executing this query
	Subject *string `json:"subject,omitempty"`
}
```

To address this, create dedicated schemas for Request and Response in the spec, so that the properties have an explicit type.
```go
type ActivityLogSpec struct {
	// Request Request object
	Request *RequestObject `json:"request,omitempty"`

	// Response Response object
	Response *ResponseObject `json:"response,omitempty"`

	// Subject User-JWT executing this query
	Subject *string `json:"subject,omitempty"`
}
```