### PR TITLE
Improve metadata.ref and metadata.resource documentation

### DIFF
--- a/spec/schemas/resource.yaml
+++ b/spec/schemas/resource.yaml
@@ -148,8 +148,20 @@ components:
     ReferenceURN:
       type: string
       description: |
-        A unique resource name used to reference this resource in other resources. The reference
-        is represented as the full URN (Uniform Resource Name) name of the resource.
+        A unique resource name (URN) used to identify and reference this resource.
+
+        The URN is NOT a URL — it does not contain a protocol scheme (http/https), a host,
+        or any endpoint-specific prefix. It is a portable, transport-agnostic identifier.
+        A configured SDK client — which knows the provider's base URL and endpoint mapping —
+        can derive a URL from a URN, but the URN alone cannot be turned into a URL without
+        that SDK configuration context. This separation keeps the URN portable across
+        environments and CSP deployments.
+
+        The full URN format is:
+          `{provider}/{version}/tenants/{tenant}/workspaces/{workspace}/{type}/{name}`
+
+        For hierarchical (nested) resources, additional parent path segments are included:
+          `seca.network/v1/tenants/tn-1/workspaces/ws-1/networks/my-net/route-tables/my-rt`
 
         ### Automatic Prefix Inference
 
@@ -172,7 +184,7 @@ components:
         The prefix inference is resolved on admission into the full URN format, which makes it
         mostly suitable for human use.
       maxLength: 255
-      example: resources/resource-a1b2c3
+      example: "seca.compute/v1/tenants/tn-1/workspaces/ws-1/instances/my-server"
 
     ReferenceObject:
       type: object
@@ -216,10 +228,15 @@ components:
         resource:
           type: string
           description: |
-            Name and type of the resource. Must be in the format `<type>/<name>`.
-            The type is the resource type, and the name is the resource name.
+            Resource-specific path identifying the resource within its workspace context.
+            This is the segment of the full URN after the provider, version, tenant, and
+            workspace parts. For a flat resource it is `<type>/<name>`, and for hierarchical
+            (nested) resources it includes the parent path segments:
+              `networks/<network-name>/route-tables/<rt-name>`
+            The provider, tenant, and workspace can be specified as separate fields in this
+            object; they do not need to be repeated here.
           maxLength: 256
-          example: resources/resource-a1b2c3
+          example: "instances/my-server"
 
     PermissionMetadata:
       type: object

--- a/website/docs/content/3. Architecture/06-resource-model.md
+++ b/website/docs/content/3. Architecture/06-resource-model.md
@@ -41,9 +41,10 @@ The fields we are currently providing are the below listed:
 
 - **name** - Resource identifier in dash-case (kebab-case) format. Must start and end with an alphanumeric character. Can contain lowercase letters, numbers, and hyphens. Multiple segments can be joined with dots. Each segment follows the same rules.
 - **provider** - resource provider which is responsible for managing the lifecycle, configuration, and operations of the resource. (E.g: seca.compute/v1)
-- **resource** - resource URN which uniquely identifies a resource within the hierarchy, following the path format 
+- **resource** - resource-specific path that identifies the resource within its workspace context. Contains the type and name segment(s) of the resource, without the provider, version, tenant, or workspace prefix (those are available as separate metadata fields):
   ```
-  tenants/{tenant-id}/workspaces/{workspace-name}/instances/{instance-name}
+  instances/{instance-name}
+  networks/{network-name}/route-tables/{rt-name}
   ```
 - **verb** - specifies the HTTP method used by the customer to perform an operation on the resource, such as GET, POST, PUT, or DELETE.
 - **createdAt** -  Indicates the time when the resource was created. The field is set by the provider and should not be modified by the user.
@@ -52,7 +53,13 @@ The fields we are currently providing are the below listed:
 - **resourceVersion** - Incremented on every modification of the resource. Used for optimistic concurrency control.
 - **apiVersion** - API version of the resource.
 - **kind** - identifies the resource type.
-- **ref** - Reference to a resource. The reference is represented as the full URN (Uniform Resource Name) name of the resource. The reference can be used to refer to a resource in other resources.
+- **ref** - Full URN (Uniform Resource Name) of the resource. The URN is **not** a URL — it has no protocol scheme, host, or endpoint prefix. It is a portable, transport-agnostic identifier. The format is:
+  ```
+  {provider}/{version}/tenants/{tenant}/workspaces/{workspace}/{type}/{name}
+  ```
+  Example: `seca.compute/v1/tenants/tn-1/workspaces/ws-1/instances/my-server`
+
+  A configured SDK client can derive a transport URL from a URN, but the URN alone is not a URL. This keeps the URN portable across environments and CSP deployments.
 - **tenant** - specifies the tenant identifier to which the resource belongs.
 - **workspace** - specifies the workspace identifier to which the resource belongs.
 - **region** -  specifies the geographical region where the resource is located.

--- a/website/docs/content/6. Examples/01. usage.md
+++ b/website/docs/content/6. Examples/01. usage.md
@@ -485,7 +485,8 @@ Content-Type: application/json
   "metadata": {
     "name": "web-shop-server",
     "provider": "seca.compute/v1",
-    "resource": "tenants/{tenant_id}/workspaces/web-shop-prod/instances/web-shop-server",
+    "ref": "seca.compute/v1/tenants/{tenant_id}/workspaces/web-shop-prod/instances/web-shop-server",
+    "resource": "instances/web-shop-server",
     "tenant": "{tenant_id}",
     "workspace": "web-shop-prod",
     "region": "europe-country-1",


### PR DESCRIPTION
Clarify that metadata.ref is a URN (not a URL), document the full URN format, and correct the metadata.resource field description and examples to reflect the resource-specific path segment (without tenant/workspace prefix). 

This pull request updates the documentation and schema to clarify the distinction between a resource's URN (Uniform Resource Name) and its resource-specific path, and to standardize how these identifiers are described and used across the codebase. The changes improve consistency, make the resource model more understandable, and ensure correct usage of URNs versus resource paths in both documentation and schema definitions.

**Clarification and Standardization of Resource Identifiers:**

* Updated the `ReferenceURN` description in `spec/schemas/resource.yaml` to clearly explain that a URN is a portable, transport-agnostic identifier, not a URL, and provided explicit examples and format details for both flat and hierarchical resources.
* Updated the `resource` field in both the schema and documentation to clarify that it represents the resource-specific path (type/name and any parent segments), excluding provider, version, tenant, and workspace, which are available as separate fields. Provided concrete examples for both flat and nested resources. [[1]](diffhunk://#diff-6844a658608e5c22760b6729611c684228ba5dd47c2eaf5ae53e3b40d9941be1L219-R239) [[2]](diffhunk://#diff-b263c3a538b36c3b9595b51f64959195d0c36d4aff764c8597040839e21c5951L44-R47)

**Documentation Improvements:**

* Revised the `ref` field description in the documentation to define it as the full URN, including a clear example and explanation of its portability and distinction from a URL.
* Updated the example in the usage documentation to include both the `ref` (full URN) and `resource` (resource-specific path), ensuring alignment with the clarified model.

**Schema Example Updates:**

* Changed the example values for both `ReferenceURN` and `resource` fields in the schema to match the clarified formats and improve guidance for users. [[1]](diffhunk://#diff-6844a658608e5c22760b6729611c684228ba5dd47c2eaf5ae53e3b40d9941be1L175-R187) [[2]](diffhunk://#diff-6844a658608e5c22760b6729611c684228ba5dd47c2eaf5ae53e3b40d9941be1L219-R239)

These changes improve the clarity and correctness of how resources are identified and referenced throughout the system.

Closes #215, closes #216.
