### PR TITLE
feat: sizegb add extra tags for field to allow easier field validation checks

### DIFF
--- a/spec/schemas/block-storage.yaml
+++ b/spec/schemas/block-storage.yaml
@@ -35,6 +35,11 @@ components:
           description: Size of the block storage in GB.
           maximum: 1000000
           example: 10
+          x-oapi-codegen-extra-tags:
+            x-cel-rule-0: '!oldSelf.hasValue() || self >= oldSelf.value()'
+            x-cel-message-0: 'spec.sizeGB cannot be decreased'
+            x-cel-rule-1: 'self > 0'
+            x-cel-message-1: 'spec.sizeGB must be greater than 0'
         sourceImageRef:
           allOf:
           - $ref: './resource.yaml#/components/schemas/Reference'


### PR DESCRIPTION
Description: 
Add validation to sizeGB:
The tag is generated in sdk as: 
<pre>
    SizeGB int `json:"sizeGB" x-cel-message-0:"spec.sizeGB cannot be decreased" x-cel-message-1:"spec.sizeGB must be greater than 0" x-cel-rule-0:"!oldSelf.hasValue() || self >= oldSelf.value()" x-cel-rule-1:"self > 0"`
</pre>

In ecp, a small go tool will add kubebuilder comments:
<pre>
	// +kubebuilder:validation:XValidation:rule="!oldSelf.hasValue() || self >= oldSelf.value()",message="spec.sizeGB cannot be decreased",optionalOldSelf=true
	// +kubebuilder:validation:XValidation:rule="self > 0",message="spec.sizeGB must be greater than 0"
	SizeGB int `json:"sizeGB" x-cel-message-0:"spec.sizeGB cannot be decreased" x-cel-message-1:"spec.sizeGB must be greater than 0" x-cel-rule-0:"!oldSelf.hasValue() || self >= oldSelf.value()" x-cel-rule-1:"self > 0"`
</pre>

The comments will be interpreted by controller-gen when generating CRDs.

Note: there is also the option of just having something like: 
<pre>
 sizeGB: 
    type: integer
    x-oapi-codegen-extra-tags:
      x-cel-preset-0: 'immutable'
</pre>
And that can be translated to what we have below. For now I kept the full 'cel' format.