### PR TITLE
Add contraints to Parameters Path

### DIFF
--- a/spec/schemas/parameters.yaml
+++ b/spec/schemas/parameters.yaml
@@ -72,6 +72,7 @@ components:
       required: true
       schema:
         type: string
+        maxLength: 64
       description: Tenant ID
 
     workspacePathParam:
@@ -80,6 +81,7 @@ components:
       required: true
       schema:
         type: string
+        maxLength: 64
       description: Workspace name
 
     networkPathParam:
@@ -88,6 +90,7 @@ components:
       required: true
       schema:
         type: string
+        maxLength: 64
       description: Network name
 
     clusterPathParam:
@@ -96,6 +99,7 @@ components:
       required: true
       schema:
         type: string
+        maxLength: 128
       description: Cluster name
 
     resourcePathParam:
@@ -104,5 +108,8 @@ components:
       required: true
       schema:
         type: string
+        maxLength: 128
+        minLength: 1
+        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
       description: Resource name
       


### PR DESCRIPTION
### Description:
Currently, we have constraints on the metadata regarding "tenant", "workspace", "network", and "resource name", but we do not have any in the path parameters.

### Result: 
<img width="792" height="447" alt="image" src="https://github.com/user-attachments/assets/60190de0-d570-489e-ba87-4921130b7aa0" />
