### PR TITLE
fix(nat-gateway): Use correct intendation to propagate properties

### DIFF
--- a/spec/schemas/nat-gateway.yaml
+++ b/spec/schemas/nat-gateway.yaml
@@ -16,15 +16,15 @@ components:
           in the subnet to access the internet while keeping their private IP addresses
           hidden. The InternetNatGatewayInstance is used in conjunction with a RouteTable to
           enable internet connectivity.
-      required:
-      - spec
-      properties:
-        metadata:
-          $ref: './resource.yaml#/components/schemas/RegionalWorkspaceResourceMetadata'
-        spec:
-          $ref: './nat-gateway.yaml#/components/schemas/InternetNatGatewayInstanceSpec'
-        status:
-          $ref: './nat-gateway.yaml#/components/schemas/InternetNatGatewayInstanceStatus'
+        required:
+        - spec
+        properties:
+          metadata:
+            $ref: './resource.yaml#/components/schemas/RegionalWorkspaceResourceMetadata'
+          spec:
+            $ref: './nat-gateway.yaml#/components/schemas/InternetNatGatewayInstanceSpec'
+          status:
+            $ref: './nat-gateway.yaml#/components/schemas/InternetNatGatewayInstanceStatus'
 
     InternetNatGatewayInstanceSpec:
       type: object


### PR DESCRIPTION
Dear SECAPI team

When using the specification with an openapi generator, we found out that some nested properties in the `nat-gateway` model were not correctly intended. As such, the resulting model is missing the metadata and status properties.

Thank you for considering this PR to fix this issue.

Additionally, I would propose a formatting tool to run on the CI pipeline to correctly set all intendations.

Best,
Christoph