### PR TITLE
fix: resolve cyclic dependency between network and route table

### DIFF
--- a/spec/schemas/network.yaml
+++ b/spec/schemas/network.yaml
@@ -41,6 +41,10 @@ components:
         only the network prefix is required. E.g. to request a /16 IPv4 CIDR block the
         CIDR block would be `0.0.0.0/16` and for a /56 IPv6 CIDR block the CIDR block would
         be `::/56`. Most CSP will not allow to use a different IPv6 prefix length than /56.
+
+        Route tables associated with this network automatically include local routes for
+        all network CIDRs (including `additionalCidrs`). These network-local routes are
+        present by default and cannot be removed.
       required:
       - cidr
       - skuRef

--- a/spec/schemas/network.yaml
+++ b/spec/schemas/network.yaml
@@ -44,7 +44,6 @@ components:
       required:
       - cidr
       - skuRef
-      - routeTableRef
       properties:
         cidr:
           $ref: './network.yaml#/components/schemas/cidr'
@@ -68,17 +67,9 @@ components:
           x-oapi-codegen-extra-tags:
             x-cel-rule-0: "self == oldSelf"
             x-cel-message-0: "spec.skuRef is immutable"
-        routeTableRef:
-          allOf:
-          - $ref: './resource.yaml#/components/schemas/Reference'
-          description: Reference to the route table used by default for all Subnets.
-          example:
-            resource: "route-tables/route-table-1"
       example:
         skuRef:
           resource: "tenants/seca/skus/n1k"
-        routeTableRef:
-          resource: "route-tables/route-table-1"
         cidr:
           ipv4: "0.0.0.0/16"
           ipv6: "::/56"
@@ -110,18 +101,10 @@ components:
               $ref: './network.yaml#/components/schemas/cidr'
             x-oapi-codegen-extra-tags:
               x-kubebuilder-validation-max-items: "32"
-          routeTableRef:
-            allOf:
-            - $ref: './resource.yaml#/components/schemas/Reference'
-            description: Reference to the route table used by default for all Subnets.
-            example:
-              resource: "route-tables/route-table-1"
         example:
           cidr:
             ipv4: "10.100.0.0/16"
             ipv6: "2001:239:203:2400::/56"
-          routeTableRef:
-            resource: "route-tables/route-table-1"
     cidr:
       type: object
       description: |

--- a/spec/schemas/rbac.yaml
+++ b/spec/schemas/rbac.yaml
@@ -174,6 +174,8 @@ components:
           items:
             $ref: "#/components/schemas/RoleAssignmentScope"
           description: List of scopes (e.g., tenant, workspace) for the role assignment
+          example:
+          - workspaces: ["workspace-1"]
           x-oapi-codegen-extra-tags:
             x-kubebuilder-validation-min-items: "1"
             x-kubebuilder-validation-max-items: "256"

--- a/spec/schemas/subnet.yaml
+++ b/spec/schemas/subnet.yaml
@@ -18,6 +18,7 @@ components:
           Key Network Routing Concepts:
           - Defines a range of IP addresses for compute instances
           - Enables network segmentation and isolation
+          - Each subnet requires an explicit route table reference
         required:
         - spec
         properties:
@@ -42,6 +43,7 @@ components:
       required:
       - cidr
       - zone
+      - routeTableRef
       properties:
         cidr:
           $ref: './network.yaml#/components/schemas/cidr'
@@ -55,8 +57,7 @@ components:
           allOf:
           - $ref: './resource.yaml#/components/schemas/Reference'
           description: |
-            Reference to the route table used by default for all NICs in this Subnet.
-            If not provided, the routeTableRef associated with the network of the subnet will be used.
+            Reference to the route table used for all NICs in this Subnet.
           example:
             resource: "route-tables/route-table-1"
         skuRef:
@@ -72,6 +73,8 @@ components:
           ipv4: "0.0.0.0/24"
           ipv6: "::/64"
         zone: "a"
+        routeTableRef:
+          resource: "route-tables/route-table-1"
         skuRef:
           resource: "tenants/seca/skus/1000"
 

--- a/website/docs/content/6. Examples/01. usage.md
+++ b/website/docs/content/6. Examples/01. usage.md
@@ -283,8 +283,7 @@ Content-Type: application/json
     "skuRef": "tenants/seca/skus/seca.n1k",
     "cidr": {
       "ipv4": "10.100.0.0/16"
-    },
-    "routeTableRef": "route-tables/web-shop-route-table"
+    }
   }
 }
 ```
@@ -350,7 +349,8 @@ Content-Type: application/json
   "spec": {
     "cidr": {
       "ipv4": "10.100.1.0/24"
-    }
+    },
+    "routeTableRef": "route-tables/web-shop-route-table"
   }
 }
 ```


### PR DESCRIPTION
Remove routeTableRef from NetworkSpec and NetworkStatus — a network cannot reference a route table that is itself scoped under that network.

Make routeTableRef required in SubnetSpec so each subnet explicitly declares its routing configuration rather than relying on an implicit network-level fallback that no longer exists.