### PR TITLE
chore: update GitHub Actions and fix stale make target

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -31,21 +31,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: '>=1.23.0'
-          cache: false 
+          cache: false
 
       - name: Generate resource APIs
-        run: make resource-apis      
+        run: make spec-apis
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.11.0
+          node-version: 22
           cache: npm # Automatically caches dependencies
           cache-dependency-path: website/package-lock.json  # 👈 Ensure caching works for the correct path
 

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -14,20 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: '>=1.23.0'
-          cache: false 
+          cache: false
 
       - name: Validate
         run: make lint
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.11.0
+          node-version: 22
           cache: npm # Automatically caches dependencies
           cache-dependency-path: website/package-lock.json  # 👈 Ensure caching works for the correct path
 


### PR DESCRIPTION
- actions/checkout v4 → v7
- actions/setup-go v4 → v6
- actions/setup-node v4 → v6
- Node.js 20.11.0 → 22 (current LTS)
- make resource-apis → make spec-apis (target was renamed)