### PR TITLE
fix(object-storage): use regional workspace instead of global tenant

### DIFF
--- a/spec/schemas/object-storage.yaml
+++ b/spec/schemas/object-storage.yaml
@@ -10,7 +10,7 @@ components:
         - spec
         properties:
           metadata:
-            $ref: './resource.yaml#/components/schemas/GlobalTenantResourceMetadata'
+            $ref: './resource.yaml#/components/schemas/RegionalWorkspaceResourceMetadata'
           spec:
             $ref: '#/components/schemas/ObjectStorageAccountSpec'
           status:


### PR DESCRIPTION
This is a fix to the wrong returned metadata by object storage.