### PR TITLE
fix(object-storage): scope ObjectStorageAccount to tenant, not workspace

### DIFF
--- a/spec/resources/objectstorage.v1beta1.yaml
+++ b/spec/resources/objectstorage.v1beta1.yaml
@@ -8,6 +8,6 @@ description: |
 resources:
   - name: account
     plural: accounts
-    hierarchy: [tenant, workspace]
+    hierarchy: [tenant]
     schema: ./schemas/object-storage.yaml#/components/schemas/ObjectStorageAccount
     operations: [list, get, put, delete]

--- a/spec/schemas/object-storage.yaml
+++ b/spec/schemas/object-storage.yaml
@@ -10,7 +10,7 @@ components:
         - spec
         properties:
           metadata:
-            $ref: './resource.yaml#/components/schemas/GlobalTenantResourceMetadata'
+            $ref: './resource.yaml#/components/schemas/RegionalWorkspaceResourceMetadata'
           spec:
             $ref: '#/components/schemas/ObjectStorageAccountSpec'
           status:

--- a/spec/schemas/object-storage.yaml
+++ b/spec/schemas/object-storage.yaml
@@ -10,7 +10,7 @@ components:
         - spec
         properties:
           metadata:
-            $ref: './resource.yaml#/components/schemas/RegionalWorkspaceResourceMetadata'
+            $ref: './resource.yaml#/components/schemas/GlobalTenantResourceMetadata'
           spec:
             $ref: '#/components/schemas/ObjectStorageAccountSpec'
           status:


### PR DESCRIPTION
## Summary
- ObjectStorageAccount is intended to be a global (tenant-scoped) resource, not workspace/region-scoped.
- Fixes the mismatch surfaced in #315: `hierarchy: [tenant, workspace]` in `spec/resources/objectstorage.v1beta1.yaml` generated workspace-scoped paths (`/v1beta1/tenants/{tenant}/workspaces/{workspace}/accounts/{name}`), which broke OpenAPI client generation.
- Instead of matching the metadata to the workspace-scoped URL (as #315 did), this reverts the metadata to `GlobalTenantResourceMetadata` and changes the hierarchy to `[tenant]`, so generated paths become `/v1beta1/tenants/{tenant}/accounts/{name}` — consistent with other global tenant resources like RBAC (`authorization.v1`).
