### PR TITLE
fix(compute): document instance action preconditions and add missing 412 response

### DIFF
--- a/spec/resources/compute.v1.yaml
+++ b/spec/resources/compute.v1.yaml
@@ -64,9 +64,21 @@ resources:
     operations: [list, get, put, delete]
     actions:
     - name: start
-      description: Power on (boot) a specific instance
+      description: |
+        Power on (boot) a specific instance.
+
+        This action is only valid when the instance's `status.powerState` is `off`. If the
+        instance is already `on`, a `409` is returned.
     - name: stop
-      description: Power off (shutdown) a specific instance
+      description: |
+        Power off (shutdown) a specific instance.
+
+        This action is only valid when the instance's `status.powerState` is `on`. If the
+        instance is already `off`, a `409` is returned.
     - name: restart
-      description: Power cycle (reboot) a specific instance
+      description: |
+        Power cycle (reboot) a specific instance.
+
+        This action is only valid when the instance's `status.powerState` is `on`. If the
+        instance is `off`, a `409` is returned.
     

--- a/spec/templates/resource.yaml.tpl
+++ b/spec/templates/resource.yaml.tpl
@@ -285,7 +285,9 @@ paths:
         '404':
           $ref: './schemas/errors.yaml#/components/responses/Error404'
         '409':
-          $ref: './schemas/errors.yaml#/components/responses/Error409'  
+          $ref: './schemas/errors.yaml#/components/responses/Error409'
+        '412':
+          $ref: './schemas/errors.yaml#/components/responses/Error412'
         '500':
           $ref: './schemas/errors.yaml#/components/responses/Error500'
     {{ end }}


### PR DESCRIPTION
## Summary
- Document that `start` requires `powerState=off` and `stop`/`restart` require `powerState=on`, returning `409` otherwise
- Add the missing `412` response to generated action endpoints (start/stop/restart), matching PUT/DELETE, since they already accept the `if-unmodified-since` header