### PR TITLE
feat: add missing CEL validations for Subnet and SecurityGroupRule

### DIFF
--- a/spec/schemas/security-group-rule.yaml
+++ b/spec/schemas/security-group-rule.yaml
@@ -15,7 +15,13 @@ components:
           metadata:
             $ref: './resource.yaml#/components/schemas/RegionalWorkspaceResourceMetadata'
           spec:
-            $ref: '#/components/schemas/SecurityGroupRuleSpec'
+            allOf:
+            - $ref: '#/components/schemas/SecurityGroupRuleSpec'
+            x-oapi-codegen-extra-tags:
+              x-cel-rule-0: "!has(self.icmp) || !has(self.protocol) || self.protocol == 'icmp'"
+              x-cel-message-0: "spec.icmp is only allowed when spec.protocol is icmp"
+              x-cel-rule-1: "!has(self.ports) || !has(self.protocol) || self.protocol != 'icmp'"
+              x-cel-message-1: "spec.ports is not allowed when spec.protocol is icmp"
           status:
             $ref: '#/components/schemas/SecurityGroupRuleStatus'
 
@@ -61,7 +67,11 @@ components:
             x-kubebuilder-validation-enum: "tcp;udp;tcp+udp;icmp"
             x-kubebuilder-validation-max-length: "7"
         ports:
-          $ref: '#/components/schemas/Ports'
+          allOf:
+          - $ref: '#/components/schemas/Ports'
+          x-oapi-codegen-extra-tags:
+            x-cel-rule-0: "!has(self.from) || !has(self.to) || self.to >= self.from"
+            x-cel-message-0: "ports.to must be greater than or equal to ports.from"
         icmp:
           $ref: '#/components/schemas/IcmpConfig'
         sourceRef:

--- a/spec/schemas/security-group.yaml
+++ b/spec/schemas/security-group.yaml
@@ -56,6 +56,10 @@ components:
             $ref: './security-group-rule.yaml#/components/schemas/SecurityGroupRuleSpec'
           x-oapi-codegen-extra-tags:
             x-kubebuilder-validation-max-items: "500"
+            x-cel-rule-0: "self.all(x, !has(x.icmp) || !has(x.protocol) || x.protocol == 'icmp')"
+            x-cel-message-0: "icmp is only allowed when protocol is icmp"
+            x-cel-rule-1: "self.all(x, !has(x.ports) || !has(x.protocol) || x.protocol != 'icmp')"
+            x-cel-message-1: "ports is not allowed when protocol is icmp"
         ruleRefs:
           type: array
           x-go-type-skip-optional-pointer: true

--- a/spec/schemas/subnet.yaml
+++ b/spec/schemas/subnet.yaml
@@ -50,7 +50,11 @@ components:
         zone:
           allOf:
           - $ref: './region.yaml#/components/schemas/Zone'
+          description: |
+            The zone in which the subnet is deployed. The zone is immutable after the subnet is created.
           x-oapi-codegen-extra-tags:
+            x-cel-rule-0: "self == oldSelf"
+            x-cel-message-0: "spec.zone is immutable"
             x-kubebuilder-validation-min-length: "1"
             x-kubebuilder-validation-max-length: "32"
         routeTableRef:
@@ -65,9 +69,12 @@ components:
           - $ref: './resource.yaml#/components/schemas/Reference'
           description: |
             Reference to the SKU used by default for all NICs in this Network.
-            Can be overridden by the NIC
+            Can be overridden by the NIC. The SKU is immutable after the subnet is created.
           example:
             resource: "tenants/seca/skus/1000"
+          x-oapi-codegen-extra-tags:
+            x-cel-rule-0: "!oldSelf.hasValue() || self == oldSelf.value()"
+            x-cel-message-0: "spec.skuRef is immutable"
       example:
         cidr:
           ipv4: "0.0.0.0/24"


### PR DESCRIPTION
## Summary
- Adds `skuRef`/`zone` immutability CEL rules to `SubnetSpec`, matching the pattern already applied to Network/NIC/Instance/BlockStorage in #305.
- Adds `Ports.from`/`Ports.to` ordering and `protocol`/`icmp`/`ports` mutual-consistency CEL rules to `SecurityGroupRuleSpec`, at both places it's referenced (`SecurityGroupSpec.rules` array and `SecurityGroupRule.spec`).

## Details
- `SubnetSpec.skuRef` — optional field, uses the `!oldSelf.hasValue() || self == oldSelf.value()` pattern (same as NIC's `skuRef`).
- `SubnetSpec.zone` — required field, uses `self == oldSelf` (same as Instance's `zone`).
- `SecurityGroupRuleSpec.ports` — `!has(self.from) || !has(self.to) || self.to >= self.from`, since plain JSON Schema can't express cross-field ordering.
- `protocol` vs `icmp`/`ports` consistency — enforced identically at both usage sites of `SecurityGroupRuleSpec` (array form via `self.all(...)` on `SecurityGroupSpec.rules`, and object form on `SecurityGroupRule.spec`).

## Verification
- `make build` — bundles cleanly, no errors.
- `make lint` — perfect score on all bundles (vacuum ruleset).
- Note: full CEL-syntax/semantic validation (`inject-kubebuilder-markers` + `controller-gen`) lives in the `ecp` repo, not here — `make build`/`lint` only prove the OpenAPI is well-formed, not that the CEL expressions compile under the K8s CEL environment. Worth a sanity check there before merge.

Closes eu-sovereign-cloud/ecp#2
Closes eu-sovereign-cloud/ecp#3